### PR TITLE
2.3.1 Text Helper Hotfix

### DIFF
--- a/data/localization/en.json
+++ b/data/localization/en.json
@@ -55,7 +55,7 @@
     "th-emphasis-example-2": "will be converted to",
     "th-emphasis-example-2-code": "&lThis is in bold, &l&oitalics&r&l, &l&mand strikethrough",
     "th-emphasis-additional-1": "Text Helper also supports",
-    "th-emphasis-additional-1-code": "``underline``",
+    "th-emphasis-additional-1-code": "__underline__",
     "th-emphasis-additional-2": "and",
     "th-emphasis-additional-2-code": "§§obfuscated§§",
 
@@ -72,7 +72,7 @@
 
     "__custom-style-dicts__": "",
     "th-custom-style-dicts": "Custom Style Dicts",
-    "th-custom-style-dicts-explanation": "Text Helper offers the posibility to create and upload custom style dicts. A style dict is a json file with a simple format.",
+    "th-custom-style-dicts-explanation": "Text Helper offers the possibility to create and upload custom style dicts. A style dict is a json file with a simple format.",
     "th-download-style-dict-template": "Download a style dict template here!",
     "th-custom-style-dicts-documentation-1": "Documentation for creating your own style dict can be found",
     "th-custom-style-dicts-documentation-2": "here.",
@@ -131,7 +131,7 @@
     "th-tag-reset": "Resets the styling.",
 
     "__all-fonts__": "",
-    "th-all-fonts": "Buildin fonts",
+    "th-all-fonts": "Built-in fonts",
     "th-support-capitals-numbers": "Supports capital letters and numbers",
     "th-support-lowercase-capitals": "Supports lowercase and capital letters",
     "th-support-numbers": "Supports numbers",

--- a/scripts/text-helper.js
+++ b/scripts/text-helper.js
@@ -204,7 +204,7 @@ const formatCodes = {
     bold: "&l",
     italic: "&o",
     strikethrough: "&m",
-    underline: "&n",
+    underlined: "&n",
     obfuscated: "&k",
     reset: "&r"
 };
@@ -238,7 +238,7 @@ const minecraftToHumanFormat = {
     "&l": "bold",
     "&o": "italic",
     "&m": "strikethrough",
-    "&n": "underline",
+    "&n": "underlined",
     "&k": "obfuscated"
 };
 

--- a/scripts/text-helper.js
+++ b/scripts/text-helper.js
@@ -386,22 +386,25 @@ class Formatter {
                 }
             }
             if (this.currentChar === "&") {
-                if (nextChar === null) continue;
-
-                const formatCode = "&" + nextChar;
-                if (formatCode in minecraftToHumanFormat) {
-                    this.pushToken();
-                    const settingsKey = minecraftToHumanFormat[formatCode];
-                    this.tokenSettings[settingsKey] = !this.tokenSettings[settingsKey];
-                    continue;
-                } else if (formatCode === "&r") {
-                    this.pushToken();
-                    this.resetTokenSettings();
-                    continue;
-                } else if (/^&[0-9a-f]$/g.test(formatCode)) {
-                    this.pushToken();
-                    this.tokenSettings.color = colorDict[formatCode];
-                    continue;
+                if (nextChar !== null) {
+                    const formatCode = "&" + nextChar;
+                    if (formatCode in minecraftToHumanFormat) {
+                        this.pushToken();
+                        const settingsKey = minecraftToHumanFormat[formatCode];
+                        this.tokenSettings[settingsKey] = !this.tokenSettings[settingsKey];
+                        this.advanceChar();
+                        continue;
+                    } else if (formatCode === "&r") {
+                        this.pushToken();
+                        this.resetTokenSettings();
+                        this.advanceChar();
+                        continue;
+                    } else if (/^&[0-9a-f]$/g.test(formatCode)) {
+                        this.pushToken();
+                        this.tokenSettings.color = formatCode;
+                        this.advanceChar();
+                        continue;
+                    }
                 }
             }
             if (this.currentChar === "#") {

--- a/scripts/text-helper.js
+++ b/scripts/text-helper.js
@@ -502,15 +502,21 @@ class Formatter {
 
     formatWhitespaces() {
         this.lastFormatCode = this.lastFormatCode || formatCodes.reset;
-
+        
         for (let i = 0; i < this.leadingSpaces; i++) {
             this.formattedText = " " + formatCodes.reset + this.formattedText;
         }
         if (this.leadingSpaces > 0) {
             this.formattedText = formatCodes.reset + this.formattedText;
         }
-
-        for (let j = 0; j < this.endingSpaces; j++) {
+        
+        if (this.endingSpaces >= 1) {
+            if (this.tokens[this.tokens.length - 1].text !== "") {
+                this.formattedText += this.lastFormatCode;
+            } 
+            this.formattedText += " ";
+        }
+        for (let j = 1; j < this.endingSpaces; j++) {
             this.formattedText += this.lastFormatCode + " ";
         }
         if (this.endingSpaces > 0) {

--- a/scripts/text-helper.js
+++ b/scripts/text-helper.js
@@ -269,10 +269,6 @@ function htmlToMinecraftColor(colorCode) {
         colorCode = colorCode.substring(1).toLowerCase();
     }
 
-    if (colorCode in colorDict) {
-        return [colorDict[colorCode], colorCode.length];
-    }
-
     let codeLength = 0;
     if (/^[0-9a-f]{6}/g.test(colorCode)) {
         codeLength = 6;
@@ -280,6 +276,11 @@ function htmlToMinecraftColor(colorCode) {
         codeLength = 3;
     }
     if (codeLength === 0) return null;
+    colorCode = colorCode.substring(0, codeLength);
+
+    if (colorCode in colorDict) {
+        return [colorDict[colorCode], codeLength];
+    }
 
     let minecraftCode = "&x";
     for (let i = 0; i < codeLength; i++) {

--- a/scripts/text-helper.js
+++ b/scripts/text-helper.js
@@ -296,18 +296,31 @@ class Formatter {
     }
 
     formatEmojis() {
-        const re = /:[a-zA-Z0-9_]+:/g
-        let match;
-        while ((match = re.exec(this.text)) != null) {
-            const matchEnd = match.index + match[0].length;
-            const key = match[0].substring(1, match[0].length - 1);
-            console.log(this.emojiDicts);
-            for (const dict of this.emojiDicts) {
-                const emoji = dict.data[key];
-                if (emoji === undefined || emoji === null) continue;
-                this.text = this.text.replaceBetween(match.index, matchEnd, emoji);
+        let newText = "";
+        outLoop:
+        for (let i = 0; i < this.text.length; i++) {
+            if (this.text[i] === ":") {
+                for (let j = i + 1; j < this.text.length; j++) {
+                    if (this.text[j] === ":") {
+                        const emojiKey = this.text.substring(i + 1, j);
+                        let emoji = null;
+                        for (const dict of this.emojiDicts) {
+                            if (emojiKey in dict.data) {
+                                emoji = dict.data[emojiKey];
+                                break;
+                            }
+                        }
+                        if (emoji !== null) {
+                            newText += emoji;
+                            i = j + 1;
+                            continue outLoop;
+                        }
+                    }
+                }
             }
+            newText += this.text[i];
         }
+        this.text = newText;
     }
 
     advanceChar(steps) {

--- a/scripts/text-helper.js
+++ b/scripts/text-helper.js
@@ -275,7 +275,7 @@ function htmlToMinecraftColor(colorCode) {
     } else if (/^[0-9a-f]{3}/g.test(colorCode)) {
         codeLength = 3;
     }
-    if (codeLength === 0) return null;
+    if (codeLength === 0) return [null, 0];
     colorCode = colorCode.substring(0, codeLength);
 
     if (colorCode in colorDict) {

--- a/text-helper.html
+++ b/text-helper.html
@@ -202,7 +202,7 @@
                             <td><code>\</code></td>
                             <td>
                                 <span class="translate" data-content="th-tag-backslash-1"></span>
-                                <code>\**</code>
+                                <code>\*\*</code>
                                 <span class="translate" data-content="th-tag-backslash-2"></span>
                                 <code>**</code>
                             </td>


### PR DESCRIPTION
### Fixed Bugs

- Grammar corrections
- Fixed underline markdown key
- Fixed issue with the `underlined` format key named `underline` at some places.
- Fixed emoji formatting
- Fixed standard DiamondFire color and format codes
- Fixed some bugs with the HTML color code conversion.
- Fixed backslash documentation
- Fixed whitespace formatting with format codes