### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,5 +1,15 @@
 "use strict";
 
+// Utility function to escape HTML special characters
+function escapeHtml(unsafe) {
+    return unsafe
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+}
+
 // * Nav Bar Elements
 const lhElements = [
     { href: "index.html", text: "nav-home" },
@@ -77,7 +87,7 @@ async function translateAll() {
     $(".translate").each(function () {
         let contentKey = $(this).attr("data-content");
         if (contentKey) {
-            $(this).append(translate(contentKey));
+            $(this).append(escapeHtml(translate(contentKey)));
         }
         let valueKey = $(this).attr("data-value");
         if (valueKey) {


### PR DESCRIPTION
Potential fix for [https://github.com/Racooder/DiamondFire-Tools/security/code-scanning/6](https://github.com/Racooder/DiamondFire-Tools/security/code-scanning/6)

To fix the problem, we need to ensure that any text derived from the `translate` function is properly escaped before being added to the DOM. This can be achieved by using a function that escapes HTML special characters. We will create a utility function `escapeHtml` to perform this task and use it to sanitize the output of the `translate` function before appending it to the DOM.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
